### PR TITLE
[DO NOT MERGE] Fix HIP build (old version)

### DIFF
--- a/cupy/random/__init__.py
+++ b/cupy/random/__init__.py
@@ -1,7 +1,5 @@
 import numpy as _numpy
 
-from cupy_backends.cuda.api import runtime
-
 
 def bytes(length):
     """Returns random bytes.
@@ -33,9 +31,6 @@ def default_rng(seed=None):  # NOQA  avoid redefinition of seed
     Returns:
         Generator: The initialized generator object.
     """  # NOQA, list of types need to be in one line for sphinx
-    if runtime.is_hip:
-        raise RuntimeError('Generator API not supported in HIP,'
-                           ' please use the legacy one.')
     if isinstance(seed, BitGenerator):
         return Generator(seed)
     elif isinstance(seed, Generator):
@@ -95,9 +90,8 @@ from cupy.random._sample import random_sample  # NOQA
 from cupy.random._sample import random_sample as random  # NOQA
 from cupy.random._sample import random_sample as ranf  # NOQA
 from cupy.random._sample import random_sample as sample  # NOQA
-if not runtime.is_hip:
-    from cupy.random._bit_generator import BitGenerator  # NOQA
-    from cupy.random._bit_generator import XORWOW  # NOQA
-    from cupy.random._bit_generator import MRG32k3a  # NOQA
-    from cupy.random._bit_generator import Philox4x3210  # NOQA
-    from cupy.random._generator import Generator  # NOQA
+from cupy.random._bit_generator import BitGenerator  # NOQA
+from cupy.random._bit_generator import XORWOW  # NOQA
+from cupy.random._bit_generator import MRG32k3a  # NOQA
+from cupy.random._bit_generator import Philox4x3210  # NOQA
+from cupy.random._generator import Generator  # NOQA

--- a/cupy/random/_bit_generator.pyx
+++ b/cupy/random/_bit_generator.pyx
@@ -8,22 +8,9 @@ from libc.stdint cimport intptr_t, uint64_t, uint32_t
 import cupy
 from cupy.cuda cimport stream
 from cupy.core.core cimport ndarray
+from cupy.random._generator cimport *
+
 from cupy.random._generator import init_curand, random_raw
-
-# We need access to the sizes here, so this is why we have this header
-# in here instead of cupy backends
-cdef extern from 'cupy_distributions.cuh' nogil:
-    cppclass curandState:
-        pass
-    cppclass curandStateMRG32k3a:
-        pass
-    cppclass curandStatePhilox4_32_10_t:
-        pass
-
-    cdef enum _RandGenerators 'RandGenerators':
-        CURAND_XOR_WOW
-        CURAND_MRG32k3a
-        CURAND_PHILOX_4x32_10
 
 
 class BitGenerator:
@@ -138,7 +125,7 @@ class XORWOW(_cuRANDGenerator):
     generator = CURAND_XOR_WOW  # Use The Enum
 
     def _type_size(self):
-        return sizeof(curandState)
+        return sizeof_curandState()
 
 
 class MRG32k3a(_cuRANDGenerator):
@@ -159,7 +146,7 @@ class MRG32k3a(_cuRANDGenerator):
     generator = CURAND_MRG32k3a
 
     def _type_size(self):
-        return sizeof(curandStateMRG32k3a)
+        return sizeof_curandStateMRG32k3a()
 
 
 class Philox4x3210(_cuRANDGenerator):
@@ -180,4 +167,4 @@ class Philox4x3210(_cuRANDGenerator):
     generator = CURAND_PHILOX_4x32_10
 
     def _type_size(self):
-        return sizeof(curandStatePhilox4_32_10_t)
+        return sizeof_curandStatePhilox4_32_10_t()

--- a/cupy/random/_generator.pyx
+++ b/cupy/random/_generator.pyx
@@ -12,6 +12,10 @@ _UINT32_MAX = 0xffffffff
 _UINT64_MAX = 0xffffffffffffffff
 
 cdef extern from 'cupy_distributions.cuh' nogil:
+    size_t get_curandState_size()
+    size_t get_curandStateMRG32k3a_size()
+    size_t get_curandStatePhilox4_32_10_t_size()
+
     void init_curand_generator(
         int generator, intptr_t state_ptr, uint64_t seed,
         ssize_t size, intptr_t stream)
@@ -30,6 +34,16 @@ cdef extern from 'cupy_distributions.cuh' nogil:
     void exponential(
         int generator, intptr_t state, intptr_t out,
         ssize_t size, intptr_t stream)
+
+
+cdef size_t sizeof_curandState():
+    return get_curandState_size()
+
+cdef size_t sizeof_curandStateMRG32k3a():
+    return get_curandStateMRG32k3a_size()
+
+cdef size_t sizeof_curandStatePhilox4_32_10_t():
+    return get_curandStatePhilox4_32_10_t_size()
 
 
 class Generator:

--- a/cupy/random/cupy_distributions.cuh
+++ b/cupy/random/cupy_distributions.cuh
@@ -11,27 +11,18 @@ enum RandGenerators{
    CURAND_PHILOX_4x32_10
 };
 
-#if CUPY_USE_HIP
-
-#include <hiprand/hiprand_kernel.h>
-
-typedef hiprandState curandState;
-typedef hiprandStateMRG32k3a {} curandStateMRG32k3a;
-typedef hiprandStatePhilox4_32_10_t {} curandStatePhilox4_32_10_t;
-
-# else
-
-#ifndef CUPY_NO_CUDA
-#include <curand_kernel.h>
-
+// forward declaration for CUDA/HIP/RTD
 void init_curand_generator(int generator, intptr_t state_ptr, uint64_t seed, ssize_t size, intptr_t stream);
 void raw(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
 void interval_32(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int32_t mx, int32_t mask);
 void interval_64(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask);
 void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, double a, double b);
 void exponential(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream);
+size_t get_curandState_size();
+size_t get_curandStateMRG32k3a_size();
+size_t get_curandStatePhilox4_32_10_t_size();
 
-# else 
+#if !defined(CUPY_USE_HIP) && defined(CUPY_NO_CUDA)
 
 typedef struct {} curandState;
 typedef struct {} curandStateMRG32k3a;
@@ -44,6 +35,9 @@ void interval_32(int generator, intptr_t state, intptr_t out, ssize_t size, intp
 void interval_64(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask) {}
 void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, double a, double b) {}
 void exponential(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
-#endif
+
+size_t get_curandState_size(...) { return 0; }
+size_t get_curandStateMRG32k3a_size(...) { return 0; }
+size_t get_curandStatePhilox4_32_10_t_size(...) { return 0; }
 #endif
 #endif

--- a/cupy/random/cupy_distributions.cuh
+++ b/cupy/random/cupy_distributions.cuh
@@ -11,8 +11,17 @@ enum RandGenerators{
    CURAND_PHILOX_4x32_10
 };
 
+#if CUPY_USE_HIP
 
-#if !defined(CUPY_NO_CUDA) && !defined(CUPY_USE_HIP)
+#include <hiprand/hiprand_kernel.h>
+
+typedef hiprandState curandState;
+typedef hiprandStateMRG32k3a {} curandStateMRG32k3a;
+typedef hiprandStatePhilox4_32_10_t {} curandStatePhilox4_32_10_t;
+
+# else
+
+#ifndef CUPY_NO_CUDA
 #include <curand_kernel.h>
 
 void init_curand_generator(int generator, intptr_t state_ptr, uint64_t seed, ssize_t size, intptr_t stream);
@@ -35,5 +44,6 @@ void interval_32(int generator, intptr_t state, intptr_t out, ssize_t size, intp
 void interval_64(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, int64_t mx, int64_t mask) {}
 void beta(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream, double a, double b) {}
 void exponential(int generator, intptr_t state, intptr_t out, ssize_t size, intptr_t stream) {}
+#endif
 #endif
 #endif

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -87,7 +87,7 @@ cuda_files = [
     'cupy.fft._callback',
     'cupy.lib._polynomial',
     'cupy.random._bit_generator',
-    'cupy.random._generator',
+    ('cupy.random._generator', ['cupy/random/cupy_distributions.cu']),
     'cupy._util'
 ]
 
@@ -127,10 +127,7 @@ if use_hip:
 else:
     MODULES.append({
         'name': 'cuda',
-        'file': cuda_files + [
-             ('cupy.random._generator',
-              ['cupy/random/cupy_distributions.cu']),
-         ],
+        'file': cuda_files,
         'include': [
             'cublas_v2.h',
             'cuda.h',
@@ -327,20 +324,6 @@ if bool(int(os.environ.get('CUPY_SETUP_ENABLE_THRUST', 1))):
             'check_method': build.check_thrust_version,
             'version_method': build.get_thrust_version,
         })
-
-
-MODULES.append({
-    'name': 'random',
-    'file': [
-        ('cupy.random._generator', ['cupy/random/cupy_distributions.cu']),
-    ],
-    'include': [
-    ],
-    'libraries': [
-        'cudart',
-        'curand',
-    ],
-})
 
 
 def ensure_module_file(file):

--- a/cupy_setup_build.py
+++ b/cupy_setup_build.py
@@ -128,9 +128,9 @@ else:
     MODULES.append({
         'name': 'cuda',
         'file': cuda_files + [
-            ('cupy.random._generator',
-             ['cupy/random/cupy_distributions.cu']),
-        ],
+             ('cupy.random._generator',
+              ['cupy/random/cupy_distributions.cu']),
+         ],
         'include': [
             'cublas_v2.h',
             'cuda.h',
@@ -265,20 +265,6 @@ if not use_hip:
         'check_method': build.check_jitify_version,
         'version_method': build.get_jitify_version,
     })
-
-    MODULES.append({
-        'name': 'random',
-        'file': [
-            ('cupy.random._generator', ['cupy/random/cupy_distributions.cu']),
-        ],
-        'include': [
-        ],
-        'libraries': [
-            'cudart',
-            'curand',
-        ],
-    })
-
 else:
     MODULES.append({
         'name': 'cub',
@@ -341,6 +327,20 @@ if bool(int(os.environ.get('CUPY_SETUP_ENABLE_THRUST', 1))):
             'check_method': build.check_thrust_version,
             'version_method': build.get_thrust_version,
         })
+
+
+MODULES.append({
+    'name': 'random',
+    'file': [
+        ('cupy.random._generator', ['cupy/random/cupy_distributions.cu']),
+    ],
+    'include': [
+    ],
+    'libraries': [
+        'cudart',
+        'curand',
+    ],
+})
 
 
 def ensure_module_file(file):

--- a/install/build.py
+++ b/install/build.py
@@ -149,7 +149,6 @@ def get_compiler_setting(use_hip):
         include_dirs.append(os.path.join(rocm_path, 'include'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'hip'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'rocrand'))
-        include_dirs.append(os.path.join(rocm_path, 'include', 'hiprand'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'roctracer'))
         library_dirs.append(os.path.join(rocm_path, 'lib'))
 

--- a/install/build.py
+++ b/install/build.py
@@ -149,6 +149,7 @@ def get_compiler_setting(use_hip):
         include_dirs.append(os.path.join(rocm_path, 'include'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'hip'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'rocrand'))
+        include_dirs.append(os.path.join(rocm_path, 'include', 'hiprand'))
         include_dirs.append(os.path.join(rocm_path, 'include', 'roctracer'))
         library_dirs.append(os.path.join(rocm_path, 'lib'))
 

--- a/tests/cupy_tests/random_tests/test_bit_generator.py
+++ b/tests/cupy_tests/random_tests/test_bit_generator.py
@@ -1,5 +1,4 @@
 import unittest
-import pytest
 
 import numpy
 
@@ -48,8 +47,6 @@ class BitGeneratorTestCase:
 @testing.with_requires('numpy>=1.17.0')
 @testing.fix_random()
 @testing.gpu
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason='HIP does not support this')
 class TestBitGeneratorXORWOW(BitGeneratorTestCase, unittest.TestCase):
     def setUp(self):
         super().setUp()
@@ -59,8 +56,6 @@ class TestBitGeneratorXORWOW(BitGeneratorTestCase, unittest.TestCase):
 @testing.with_requires('numpy>=1.17.0')
 @testing.fix_random()
 @testing.gpu
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason='HIP does not support this')
 class TestBitGeneratorMRG32k3a(BitGeneratorTestCase, unittest.TestCase):
     def setUp(self):
         super().setUp()
@@ -70,8 +65,6 @@ class TestBitGeneratorMRG32k3a(BitGeneratorTestCase, unittest.TestCase):
 @testing.with_requires('numpy>=1.17.0')
 @testing.fix_random()
 @testing.gpu
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason='HIP does not support this')
 class TestBitGeneratorPhilox4x3210(BitGeneratorTestCase, unittest.TestCase):
     def setUp(self):
         super().setUp()

--- a/tests/cupy_tests/random_tests/test_generator.py
+++ b/tests/cupy_tests/random_tests/test_generator.py
@@ -1,7 +1,6 @@
 import functools
 import threading
 import unittest
-import pytest
 
 import numpy
 
@@ -75,8 +74,6 @@ def two_sample_Kolmogorov_Smirnov_test(observed1, observed2):
     return d_plus, d_minus, p
 
 
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason='HIP does not support this')
 class GeneratorTestCase(unittest.TestCase):
 
     target_method = None
@@ -266,8 +263,6 @@ class TestIntegers(GeneratorTestCase):
 
 @testing.with_requires('numpy>=1.17.0')
 @testing.gpu
-@pytest.mark.skipif(cupy.cuda.runtime.is_hip,
-                    reason='HIP does not support this')
 class TestRandomStateThreadSafe(unittest.TestCase):
 
     def test_default_rng_thread_safe(self):


### PR DESCRIPTION
I was wondering what the function pointer bug was about, so I did a little experiment and reproduced what you mentioned:
```
    building 'cupy.random._generator' extension
    gcc -pthread -B /home/leofang/miniconda3/envs/cupy_rocm35_dev/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -D_FORCE_INLINES=1 -DCUPY_USE_HIP=1 -D__HIP_PLATFORM_HCC__=1 -DCUPY_CUB_VERSION_CODE=201001 -I/opt/rocm/include/hipcub -I/home/leofang/dev/cupy_rocm350/install/../cupy/core/include -I/opt/rocm/include -I/opt/rocm/include/hip -I/opt/rocm/include/rocrand -I/opt/rocm/include/hiprand -I/opt/rocm/include/roctracer -I/home/leofang/miniconda3/envs/cupy_rocm35_dev/include/python3.7m -c cupy/random/_generator.cpp -o build/temp.linux-x86_64-3.7/cupy/random/_generator.o -std=c++11
    cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
    HIPCC options: ['-O2', '-fPIC', '--include', 'hip_runtime.h']
    /opt/rocm/bin/hipcc -D_FORCE_INLINES=1 -DCUPY_USE_HIP=1 -D__HIP_PLATFORM_HCC__=1 -DCUPY_CUB_VERSION_CODE=201001 -I/opt/rocm/include/hipcub -I/home/leofang/dev/cupy_rocm350/install/../cupy/core/include -I/opt/rocm/include -I/opt/rocm/include/hip -I/opt/rocm/include/rocrand -I/opt/rocm/include/hiprand -I/opt/rocm/include/roctracer -I/home/leofang/miniconda3/envs/cupy_rocm35_dev/include/python3.7m -c cupy/random/cupy_distributions.cu -o build/temp.linux-x86_64-3.7/cupy/random/cupy_distributions.o -O2 -fPIC --include hip_runtime.h
    In file included from <built-in>:1:
    In file included from /opt/rocm/include/hip/hip_runtime.h:53:
    /opt/rocm/include/hip/hip_common.h:30:9: warning: '__HIP_PLATFORM_HCC__' macro redefined [-Wmacro-redefined]
    #define __HIP_PLATFORM_HCC__
            ^
    <command line>:6:9: note: previous definition is here
    #define __HIP_PLATFORM_HCC__ 1
            ^
    In file included from <built-in>:1:
    In file included from /opt/rocm/include/hip/hip_runtime.h:56:
    In file included from /opt/rocm/include/hip/hcc_detail/hip_runtime.h:480:
    /opt/rocm/include/hip/hcc_detail/math_functions.h:1414:19: warning: duplicate 'static' declaration specifier [-Wduplicate-decl-specifier]
    __DEVICE__ inline static T min(T arg1, T arg2) {
                      ^~~~~~~
    /opt/rocm/include/hip/hcc_detail/math_functions.h:1419:19: warning: duplicate 'static' declaration specifier [-Wduplicate-decl-specifier]
    __DEVICE__ inline static T max(T arg1, T arg2) {
                      ^~~~~~~
    3 warnings generated when compiling for gfx906.
    error: <unknown>:0:0: in function _Z23rk_standard_exponentialP8rk_state double (%struct.rk_state*): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z17rk_standard_gammaP8rk_stated double (%struct.rk_state*, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z17rk_standard_gammaP8rk_stated double (%struct.rk_state*, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z17rk_standard_gammaP8rk_stated double (%struct.rk_state*, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z17rk_standard_gammaP8rk_stated double (%struct.rk_state*, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z17rk_standard_gammaP8rk_stated double (%struct.rk_state*, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z7rk_betaP8rk_statedd double (%struct.rk_state*, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z7rk_betaP8rk_statedd double (%struct.rk_state*, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z7rk_betaP8rk_statedd double (%struct.rk_state*, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z7rk_betaP8rk_statedd double (%struct.rk_state*, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z7rk_betaP8rk_statedd double (%struct.rk_state*, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z7rk_betaP8rk_statedd double (%struct.rk_state*, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z7rk_betaP8rk_statedd double (%struct.rk_state*, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z7rk_betaP8rk_statedd double (%struct.rk_state*, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z7rk_betaP8rk_statedd double (%struct.rk_state*, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z7rk_betaP8rk_statedd double (%struct.rk_state*, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z7rk_betaP8rk_statedd double (%struct.rk_state*, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z7rk_betaP8rk_statedd double (%struct.rk_state*, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z6rk_rawP8rk_state i32 (%struct.rk_state*): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z14rk_interval_32P8rk_statejj i32 (%struct.rk_state*, i32, i32): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z14rk_interval_32P8rk_statejj i32 (%struct.rk_state*, i32, i32): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z14rk_interval_64P8rk_statemm i64 (%struct.rk_state*, i64, i64): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z14rk_interval_64P8rk_statemm i64 (%struct.rk_state*, i64, i64): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z14rk_interval_64P8rk_statemm i64 (%struct.rk_state*, i64, i64): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z14rk_interval_64P8rk_statemm i64 (%struct.rk_state*, i64, i64): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI19interval_32_functor19curand_pseudo_stateI12hiprandStateEiJjjEEvlllDpT2_ void (i64, i64, i64, i32, i32): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI19interval_32_functor19curand_pseudo_stateI20hiprandStateMRG32k3aEiJjjEEvlllDpT2_ void (i64, i64, i64, i32, i32): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI19interval_32_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10EiJjjEEvlllDpT2_ void (i64, i64, i64, i32, i32): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI19interval_64_functor19curand_pseudo_stateI12hiprandStateElJmmEEvlllDpT2_ void (i64, i64, i64, i64, i64): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI19interval_64_functor19curand_pseudo_stateI12hiprandStateElJmmEEvlllDpT2_ void (i64, i64, i64, i64, i64): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI19interval_64_functor19curand_pseudo_stateI20hiprandStateMRG32k3aElJmmEEvlllDpT2_ void (i64, i64, i64, i64, i64): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI19interval_64_functor19curand_pseudo_stateI20hiprandStateMRG32k3aElJmmEEvlllDpT2_ void (i64, i64, i64, i64, i64): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI19interval_64_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10ElJmmEEvlllDpT2_ void (i64, i64, i64, i64, i64): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI19interval_64_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10ElJmmEEvlllDpT2_ void (i64, i64, i64, i64, i64): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI19interval_64_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10ElJmmEEvlllDpT2_ void (i64, i64, i64, i64, i64): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI12hiprandStateEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI12hiprandStateEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI12hiprandStateEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI12hiprandStateEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI12hiprandStateEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI12hiprandStateEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI12hiprandStateEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI12hiprandStateEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI12hiprandStateEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI12hiprandStateEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI12hiprandStateEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI20hiprandStateMRG32k3aEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI20hiprandStateMRG32k3aEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI20hiprandStateMRG32k3aEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI20hiprandStateMRG32k3aEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI20hiprandStateMRG32k3aEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI20hiprandStateMRG32k3aEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI20hiprandStateMRG32k3aEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI20hiprandStateMRG32k3aEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI20hiprandStateMRG32k3aEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI20hiprandStateMRG32k3aEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI20hiprandStateMRG32k3aEdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10EdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10EdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10EdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10EdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10EdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10EdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10EdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10EdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10EdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10EdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    error: <unknown>:0:0: in function _Z12execute_distI12beta_functor19curand_pseudo_stateI25hiprandStatePhilox4_32_10EdJddEEvlllDpT2_ void (i64, i64, i64, double, double): unsupported indirect call to function <unknown>

    clang-11: error: amdgcn-link command failed with exit code 1 (use -v to see invocation)
    warning: cupy_backends/cuda/api/runtime.pyx:832:16: Unreachable code
    error: command '/opt/rocm/bin/hipcc' failed with exit status 1
```